### PR TITLE
Bump lokue dep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "async": "^2.6.1",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git",
     "lodash": "^4.17.10",
-    "lokue": "^0.0.8"
+    "lokue": "^0.0.9"
   },
   "engine": {
     "node": ">=8.0"


### PR DESCRIPTION
This PR bumps `lokue` dep version due to the last fix https://github.com/bitfinexcom/lokue/pull/3